### PR TITLE
I've updated the README.md to provide OS-specific commands for Window…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,19 @@ in makeup-artist-frontend -> run build corresponds to "build": "ng build --confi
 
 ## Running the Backend
 
-To start the backend Spring Boot application, navigate to the `backend` directory and run the following command:
+To start the backend Spring Boot application, navigate to the `backend` directory and run the appropriate command for your operating system:
 
-```bash
-cd backend
-./mvnw spring-boot:run
-```
+- **For Windows:**
+  ```bash
+  cd backend
+  mvnw.cmd spring-boot:run
+  ```
+
+- **For macOS/Linux:**
+  ```bash
+  cd backend
+  ./mvnw spring-boot:run
+  ```
 
 This will start the backend server.
 
@@ -18,13 +25,20 @@ This will start the backend server.
 The frontend is an Angular application. The `frontend-maven-plugin` is configured to download and use a local version of Node.js and npm.
 
 1.  **Install Node.js, npm, and frontend dependencies:**
-    Navigate to the `frontend` directory and run the Maven install command. This step ensures that Node.js and npm are installed locally (in `frontend/target/node`) and then `npm install` is executed.
+    Navigate to the `frontend` directory and run the Maven install command appropriate for your operating system. This step ensures that Node.js and npm are installed locally (in `frontend/target/node`) and then `npm install` is executed.
 
-    ```bash
-    cd frontend
-    ./../backend/mvnw clean install
-    ```
-    *(Note: We use `../backend/mvnw` because the `mvnw` wrapper is in the `backend` directory. If you have Maven installed globally and configured on your PATH, you can use `mvn clean install` directly from the `frontend` directory after an initial `cd frontend`.)*
+    - **For Windows:**
+      ```bash
+      cd frontend
+      ../backend/mvnw.cmd clean install
+      ```
+
+    - **For macOS/Linux:**
+      ```bash
+      cd frontend
+      ../backend/./mvnw clean install
+      ```
+    *(Note: We use `../backend/mvnw.cmd` or `../backend/./mvnw` because the Maven wrapper scripts are in the `backend` directory. If you have Maven installed globally and configured on your PATH, you can use `mvn clean install` directly from the `frontend` directory after an initial `cd frontend`.)*
 
 2.  **Start the Angular development server:**
     After the above command completes, navigate to the frontend application's source directory and use the locally installed npm to start the server.


### PR DESCRIPTION
…s users versus macOS/Linux users when invoking the Maven wrapper (mvnw).

For the backend:
- Windows: `mvnw.cmd spring-boot:run`
- macOS/Linux: `./mvnw spring-boot:run`

For building the frontend (from the frontend directory):
- Windows: `../backend/mvnw.cmd clean install`
- macOS/Linux: `../backend/./mvnw clean install`

The command for starting the Angular development server (`npm start`) remains the same as it's generally cross-platform once npm is correctly invoked via its path.