### PR TITLE
Here's a proposed change to the README.md file to help you troublesho…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ in makeup-artist-frontend -> run build corresponds to "build": "ng build --confi
 
 ## Running the Backend
 
+*(If `mvnw.cmd` or `./mvnw` fails with a properties file error, please see the "Troubleshooting Missing Maven Wrapper" section below.)*
+
 To start the backend Spring Boot application, navigate to the `backend` directory and run the appropriate command for your operating system:
 
 - **For Windows:**
@@ -25,6 +27,7 @@ This will start the backend server.
 The frontend is an Angular application. The `frontend-maven-plugin` is configured to download and use a local version of Node.js and npm.
 
 1.  **Install Node.js, npm, and frontend dependencies:**
+    *(If `../backend/mvnw.cmd` or `../backend/./mvnw` fails with a properties file error, please see the "Troubleshooting Missing Maven Wrapper" section below.)*
     Navigate to the `frontend` directory and run the Maven install command appropriate for your operating system. This step ensures that Node.js and npm are installed locally (in `frontend/target/node`) and then `npm install` is executed.
 
     - **For Windows:**
@@ -48,3 +51,29 @@ The frontend is an Angular application. The `frontend-maven-plugin` is configure
     ../../../target/node/npm start
     ```
     This will start the frontend development server, typically on `http://localhost:4200`.
+
+### Troubleshooting Missing Maven Wrapper
+
+If you encounter an error like "Impossibile trovare il percorso ... maven-wrapper.properties" or "Cannot start maven from wrapper", it means the Maven wrapper files are missing or corrupted in your `backend/.mvn/wrapper/` directory.
+
+To regenerate the Maven wrapper files for the backend module:
+
+1.  **Ensure you have Apache Maven installed globally.** You can download it from [https://maven.apache.org/download.cgi](https://maven.apache.org/download.cgi) and make sure it's added to your system's PATH. This is a temporary requirement to fix the wrapper.
+2.  **Navigate to the `backend` directory** in your project.
+    ```bash
+    cd backend
+    ```
+3.  **Run the Maven wrapper command:**
+    ```bash
+    mvn wrapper:wrapper
+    ```
+    This command will download the necessary `maven-wrapper.jar` and create the `maven-wrapper.properties` file in the `backend/.mvn/wrapper/` directory. It will also ensure `mvnw` and `mvnw.cmd` are up to date.
+4.  **Important:** After running this command, you should see new or updated files in `backend/.mvn/wrapper/` (and potentially `backend/mvnw`, `backend/mvnw.cmd`). **These files should be committed to your Git repository.** This ensures that other users can build the project without needing a global Maven installation.
+
+    Example commit commands:
+    ```bash
+    git add .mvn/wrapper/maven-wrapper.jar .mvn/wrapper/maven-wrapper.properties mvnw mvnw.cmd
+    git commit -m "Fix: Regenerate Maven wrapper files for backend module"
+    ```
+
+Once these files are regenerated and committed, the `./mvnw` (macOS/Linux) or `mvnw.cmd` (Windows) commands should work correctly.


### PR DESCRIPTION
…ot missing Maven wrapper files:

**Doc: Add troubleshooting for missing Maven wrapper files**

This adds a new section explaining how to regenerate the Maven wrapper files for the backend module if they are missing or corrupted. This addresses feedback I received about issues with `maven-wrapper.properties` not being found.

The new section includes:
- The prerequisite of temporarily having a global Maven installation.
- The command `mvn wrapper:wrapper` to be run in the `backend` directory.
- Emphasis on committing the newly generated/updated wrapper files (specifically `backend/.mvn/wrapper/*`, `backend/mvnw`, and `backend/mvnw.cmd`) to the repository.

Additionally, I've added notes to the "Running the Backend" and "Running the Frontend" sections to direct you to this troubleshooting guide if you encounter errors with `mvnw` or `mvnw.cmd`.